### PR TITLE
Update VoLTE Roaming Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,10 +84,10 @@
           to the emergency services.
         </p>
         <p>
-          Three is the only confirmed network (as of 30 May 2022) to have VoLTE
-          support when roaming. Some networks, such as giffgaff, have zero
-          support for VoLTE whatsoever, and this should be a number one priority
-          for them.
+          The major networks in Britain have developed their VoLTE offering to 
+          the point where they offer VoLTE Roaming in multiple countries around 
+          the world. Yet some networks, such as giffgaff, have zero support for 
+          VoLTE whatsoever, and this should be a number one priority for them.
         </p>
 
         <h2>What are they missing?</h2>


### PR DESCRIPTION
Update VoLTE Roaming section to reflect that most major UK networks now have a VoLTE Roaming offering and not just <3 3UK <3.